### PR TITLE
chore: upgrade Koog 0.8.0 -> 1.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 val kotlin_version: String by project
 val logback_version: String by project
 val koog_agents_version: String by project
+val koog_beta_version: String by project
 val dotenv_kotlin_version: String by project
 val ktor_version: String by project
 
@@ -36,5 +37,9 @@ dependencies {
     implementation("ch.qos.logback:logback-classic:${logback_version}")
 
     implementation("ai.koog:koog-agents:$koog_agents_version")
+    implementation("ai.koog:prompt-executor-llms-all:$koog_beta_version")
+    implementation("ai.koog:prompt-executor-google-client:$koog_beta_version")
+    implementation("ai.koog:prompt-executor-deepseek-client:$koog_beta_version")
+    implementation("ai.koog:prompt-executor-openrouter-client:$koog_beta_version")
     implementation("io.github.cdimascio:dotenv-kotlin:$dotenv_kotlin_version")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,6 @@ kotlin.code.style=official
 kotlin_version=2.1.10
 ktor_version=3.1.3
 logback_version=1.4.14
-koog_agents_version=0.8.0
+koog_agents_version=1.0.0
+koog_beta_version=1.0.0-beta-preview7
 dotenv_kotlin_version=6.4.1

--- a/src/main/kotlin/agent/MobileTestAgent.kt
+++ b/src/main/kotlin/agent/MobileTestAgent.kt
@@ -112,7 +112,7 @@ object MobileTestAgent {
                 }
 
                 onAgentExecutionFailed { eventContext ->
-                    println("An error occurred: ${eventContext.throwable.message}\n${eventContext.throwable.stackTraceToString()}")
+                    println("An error occurred: ${eventContext.error.message}\n${eventContext.error.stackTraceToString()}")
                 }
 
                 onAgentCompleted { eventContext ->

--- a/src/main/kotlin/agent/executor/DeepSeekExecutor.kt
+++ b/src/main/kotlin/agent/executor/DeepSeekExecutor.kt
@@ -11,5 +11,5 @@ class DeepSeekExecutor : ExecutorInfo {
 
     @OptIn(ExperimentalTime::class)
     override val executor = MultiLLMPromptExecutor(DeepSeekLLMClient(dotenv["DEEP_SEEK_KEY"]))
-    override val llmModel = DeepSeekModels.DeepSeekChat
+    override val llmModel = DeepSeekModels.DeepSeekV4Flash
 }

--- a/src/main/kotlin/agent/strategy/TestingStrategy.kt
+++ b/src/main/kotlin/agent/strategy/TestingStrategy.kt
@@ -1,68 +1,55 @@
 package agent.strategy
 
-import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.*
-import ai.koog.agents.core.environment.ReceivedToolResult
+import ai.koog.agents.core.dsl.extension.ReceivedToolResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
+import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
+import ai.koog.agents.core.dsl.extension.nodeLLMRequest
+import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
+import ai.koog.agents.core.dsl.extension.onTextMessage
+import ai.koog.agents.core.dsl.extension.onToolCalls
 
 object TestingStrategy {
-    // Compress history only when token usage gets close to crowding the context window.
-    // The previous value (1000) triggered compression on virtually every tool call, destroying step-by-step memory.
     private const val MAX_TOKENS_THRESHOLD = 8000
 
-    // Defines the agent's workflow strategy for calculator operations
     val strategy = strategy<String, String>("TestingStrategy") {
-        // Node: Requests LLM for multiple tool calls
-        val nodeCallLLM by nodeLLMRequestMultiple()
-        // Node: Executes multiple tools in parallel
-        val nodeExecuteToolMultiple by nodeExecuteMultipleTools(parallelTools = true)
-        // Node: Sends multiple tool results back to LLM
-        val nodeSendToolResultMultiple by nodeLLMSendMultipleToolResults()
-        // Node: Compresses history if token usage is high
-        val nodeCompressHistory by nodeLLMCompressHistory<List<ReceivedToolResult>>()
+        val nodeCallLLM by nodeLLMRequest()
+        val nodeExecuteToolMultiple by nodeExecuteTools(parallel = true)
+        val nodeSendToolResultMultiple by nodeLLMSendToolResults()
+        val nodeCompressHistory by nodeLLMCompressHistory<ReceivedToolResults>()
 
-        // Start: Forward to LLM to determine next action
         edge(nodeStart forwardTo nodeCallLLM)
 
-        // If LLM returns an assistant message, finish with the first result
         edge(
             (nodeCallLLM forwardTo nodeFinish)
-                    transformed { it.first() }
-                    onAssistantMessage { true }
+                    onTextMessage { true }
         )
 
-        // If LLM requests multiple tool calls, execute them in parallel
         edge(
             (nodeCallLLM forwardTo nodeExecuteToolMultiple)
-                    onMultipleToolCalls { true }
+                    onToolCalls { true }
         )
 
-        // If token usage exceeds threshold, compress history before sending results
         edge(
             (nodeExecuteToolMultiple forwardTo nodeCompressHistory)
                     onCondition { llm.readSession { prompt.latestTokenUsage > MAX_TOKENS_THRESHOLD } }
         )
 
-        // After compressing history, send tool results to LLM
         edge(nodeCompressHistory forwardTo nodeSendToolResultMultiple)
 
-        // If token usage is within threshold, send tool results directly to LLM
         edge(
             (nodeExecuteToolMultiple forwardTo nodeSendToolResultMultiple)
                     onCondition { llm.readSession { prompt.latestTokenUsage <= MAX_TOKENS_THRESHOLD } }
         )
 
-        // If LLM requests more tool calls after receiving results, execute again
         edge(
             (nodeSendToolResultMultiple forwardTo nodeExecuteToolMultiple)
-                    onMultipleToolCalls { true }
+                    onToolCalls { true }
         )
 
-        // If LLM returns an assistant message after tool results, finish with the first result
         edge(
             (nodeSendToolResultMultiple forwardTo nodeFinish)
-                    transformed { it.first() }
-                    onAssistantMessage { true }
+                    onTextMessage { true }
         )
     }
 }


### PR DESCRIPTION
## Summary
- Bumps `koog-agents` from **0.8.0** to **1.0.0**.
- Stable 1.0.0 ships Anthropic/OpenAI/Ollama clients but **not** Google/DeepSeek/OpenRouter or the `simple*Executor` helpers in `prompt-executor-llms-all` — those are still `1.0.0-beta-preview7`. Pulled explicitly to keep all 6 executors working.
- Fixes all breaking changes surfaced by `./gradlew compileKotlin`:
  - Strategy DSL renames: `nodeLLMRequestMultiple` -> `nodeLLMRequest`, `nodeExecuteMultipleTools` -> `nodeExecuteTools(parallel = true)`, `nodeLLMSendMultipleToolResults` -> `nodeLLMSendToolResults`.
  - Edge predicates: `onAssistantMessage` -> `onTextMessage`, `onMultipleToolCalls` -> `onToolCalls` (no more `transformed { it.first() }` needed — `nodeLLMRequest` returns a single `Message.Assistant`).
  - `nodeLLMCompressHistory<List<ReceivedToolResult>>` -> `nodeLLMCompressHistory<ReceivedToolResults>` (1.0 uses the singular wrapper type).
  - `AgentExecutionFailedContext.throwable` -> `error`.
  - `DeepSeekModels.DeepSeekChat` was removed; switched to `DeepSeekV4Flash`.

## Test plan
- [x] `./gradlew compileKotlin` passes
- [x] `./gradlew run` boots the server on :8080
- [x] `POST /run-test` against a connected device exercises the full strategy graph (LLM call -> parallel tool execution -> tool results -> finish)
- [x] Smoke each executor by toggling `executorInfoId` via `POST /config`: `deepseek`, `gemini`, `haiku`, `open_router`, `ollama_llama`, `ollama_gwen`
- [x] Verify history compression still triggers above `MAX_TOKENS_THRESHOLD = 8000`