### PR TITLE
Expose all executors in Settings dropdown and refresh model docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ All implement `ExecutorInfo` in `agent/executor/`. Selected via `POST /config` (
 
 | `executorInfoId` | Class | Env var |
 |---|---|---|
-| `deepseek` *(default)* | `DeepSeekExecutor` | `DEEP_SEEK_KEY` |
+| `deepseek` *(default)* | `DeepSeekExecutor` (DeepSeek V4 Flash) | `DEEP_SEEK_KEY` |
 | `gemini` | `GeminiExecutor` (Gemini 2.5 Flash) | `GEMINI_API_KEY` |
 | `haiku` | `HaikuExecutor` (Claude Haiku 4.5) | `CLAUDE_API_KEY` |
 | `open_router` | `OpenRouterExecutor` (GPT-4) | `OPEN_ROUTER` |

--- a/docs/ai-agent.md
+++ b/docs/ai-agent.md
@@ -145,13 +145,13 @@ All concrete implementations live under [agent/executor/](../src/main/kotlin/age
 | ID (`executorInfoId`) | Class | Model | API key env var |
 |---|---|---|---|
 | `gemini` | `GeminiExecutor` | `GoogleModels.Gemini2_5Flash` | `GEMINI_API_KEY` |
-| `deepseek` | `DeepSeekExecutor` | `DeepSeekModels.DeepSeekChat` | `DEEP_SEEK_KEY` |
+| `deepseek` | `DeepSeekExecutor` | `DeepSeekModels.DeepSeekV4Flash` | `DEEP_SEEK_KEY` |
 | `haiku` | `HaikuExecutor` | `AnthropicModels.Haiku_4_5` | `CLAUDE_API_KEY` |
 | `open_router` | `OpenRouterExecutor` | `OpenRouterModels.GPT4` | `OPEN_ROUTER` |
 | `ollama_llama` | `OllamaLlamaExecutor` | `OllamaModels.Meta.LLAMA_3_2_3B` | — (local) |
 | `ollama_gwen` | `OllamaGwenExecutor` | `OllamaModels.Alibaba.QWEN_3_06B` | — (local) |
 
-The default executor when the JVM starts is **`DeepSeekExecutor`** — see the default value on [MobileTesterConfig](../src/main/kotlin/agent/model/MobileTesterConfig.kt). The frontend's default selection on the Settings page is `gemini`.
+The default executor when the JVM starts is **`DeepSeekExecutor`** — see the default value on [MobileTesterConfig](../src/main/kotlin/agent/model/MobileTesterConfig.kt). The frontend's Settings page leaves the model unselected by default (the Save button is disabled until the user picks one); selecting and saving posts `executorInfoId` to `/config`, which swaps the live executor for subsequent `/run-test` calls.
 
 ### Adding a new executor
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,7 +116,7 @@ src/main/kotlin/
     ├── executor/
     │   ├── ExecutorInfo.kt      # interface { executor, llmModel }
     │   ├── GeminiExecutor.kt    # Google Gemini 2.5 Flash
-    │   ├── DeepSeekExecutor.kt  # DeepSeek Chat
+    │   ├── DeepSeekExecutor.kt  # DeepSeek V4 Flash
     │   ├── HaikuExecutor.kt     # Anthropic Claude Haiku 4.5
     │   ├── OpenRouterExecutor.kt# OpenRouter GPT-4
     │   ├── OllamaLlamaExecutor.kt # Local Ollama, Llama 3.2 3B

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -121,13 +121,15 @@ await axios.post('/api/run-test', payload, {
 Model dropdown options:
 
 ```
-open_router  → Open Router GPT-4
-ollama_gwen  → Ollama Gwen 3.0 6B
-gemini       → Gemini 2.0 Flash
-ollama_llama → Ollama LLaMA 3.2 3B
+deepseek     → DeepSeek V4 Flash
+gemini       → Gemini 2.5 Flash
+haiku        → Anthropic Claude Haiku 4.5
+open_router  → OpenRouter GPT-4
+ollama_gwen  → Ollama Qwen 3 0.6B (local)
+ollama_llama → Ollama LLaMA 3.2 3B (local)
 ```
 
-> Note: the dropdown does not yet list `haiku` or `deepseek` despite the backend accepting them. Add `<option>`s to expose them.
+The dropdown exposes every `executorInfoId` the backend accepts (see [`MobileTesterConfigAPI.toMobileConfig()`](../src/main/kotlin/server/model/MobileTesterConfigAPI.kt)). Adding a new executor on the backend requires adding a matching `<option>` here so users can pick it.
 
 `handleSave` writes everything to `localStorage`, then `fetch`-POSTs to `/api/config` and reports success/failure via a translated message.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -117,7 +117,7 @@ You have two ways to trigger a run.
 ### Via the dashboard
 
 1. Open `http://localhost:5173`.
-2. Settings → pick a model (e.g. `Gemini 2.0 Flash`), set **App Identifier** to the package id / bundle id of the app under test (this is required — there is no default), **Save**.
+2. Settings → pick a model (e.g. `Gemini 2.5 Flash`, `DeepSeek V4 Flash`, or `Anthropic Claude Haiku 4.5`), set **App Identifier** to the package id / bundle id of the app under test (this is required — there is no default), **Save**.
 3. Home → write a goal (e.g. *"Verify the create-post flow"*), add steps (one line each), **Run Test**.
 4. Wait for the PASS/FAIL summary.
 

--- a/web/src/pages/settings/Settings.tsx
+++ b/web/src/pages/settings/Settings.tsx
@@ -100,10 +100,12 @@ const Settings: React.FC = () => {
                 onChange={(e) => setExecutorInfoId(e.target.value)}
               >
                 <option value="">{t('settings.selectModelPlaceholder')}</option>
-                <option value="open_router">Open Router GPT-4</option>
-                <option value="ollama_gwen">Ollama Gwen 3.0 6B</option>
-                <option value="gemini">Gemini 2.0 Flash</option>
-                <option value="ollama_llama">Ollama LLaMA 3.2 3B</option>
+                <option value="deepseek">DeepSeek V4 Flash</option>
+                <option value="gemini">Gemini 2.5 Flash</option>
+                <option value="haiku">Anthropic Claude Haiku 4.5</option>
+                <option value="open_router">OpenRouter GPT-4</option>
+                <option value="ollama_gwen">Ollama Qwen 3 0.6B (local)</option>
+                <option value="ollama_llama">Ollama LLaMA 3.2 3B (local)</option>
               </select>
             </div>
 


### PR DESCRIPTION
## Summary
The backend's `MobileTesterConfigAPI.toMobileConfig()` accepts six `executorInfoId` values (`deepseek`, `gemini`, `haiku`, `open_router`, `ollama_gwen`, `ollama_llama`), but the Settings dropdown only exposed four — and the labels were stale after the recent model bumps (Gemini 2.0 → 2.5 Flash, DeepSeek Chat → V4 Flash, Haiku 4.5 newly added). The frontend now lists every executor with the correct model name so the picked option is what the backend actually runs.

### Changes
- [web/src/pages/settings/Settings.tsx](web/src/pages/settings/Settings.tsx): add `deepseek` and `haiku` options, rename Gemini to `2.5 Flash`, label DeepSeek as `V4 Flash`, mark Ollama options as local.
- [docs/frontend.md](docs/frontend.md): refresh the model list table and drop the stale "haiku/deepseek not listed" note.
- [docs/getting-started.md](docs/getting-started.md): widen the example model choices in the walkthrough.
- [docs/ai-agent.md](docs/ai-agent.md): update DeepSeek model id to `DeepSeekV4Flash`, and clarify that the Settings page starts unselected and that saving posts to `/config` to swap the live executor.
- [docs/architecture.md](docs/architecture.md), [CLAUDE.md](CLAUDE.md): match the new DeepSeek V4 Flash label.

No backend changes — the `/config` ↔ `/run-test` plumbing already routes the chosen `executorInfoId` to the active executor. This PR just makes the frontend faithfully expose the choices.

## Test plan
- [ ] `cd web && npx tsc -b` passes (verified locally).
- [ ] Dashboard Settings page lists six options; saving each one in turn returns 200 from `POST /api/config`.
- [ ] After saving `haiku`, a `POST /run-test` is handled by `HaikuExecutor` (confirm via backend log `Configuration updated: ...executorInfoId=haiku...`).