### PR TITLE
feat: improve UI/UX for test scenario management

### DIFF
--- a/src/main/kotlin/agent/MobileTestAgent.kt
+++ b/src/main/kotlin/agent/MobileTestAgent.kt
@@ -69,6 +69,8 @@ object MobileTestAgent {
                     SELECTOR STRATEGY (most to least reliable):
                       resource-id > content-desc > text. Pass selectorType when you know which attribute applies.
                       Default "any" searches all three.
+                      For positional/semantic steps ("last", "newest", "cheapest", icon-only), call
+                      perceiveScreen() once, pick the right node, then tap by its text or by tapByCoordinates(cx,cy).
 
                     TOOL RESULT CONVENTION:
                       Every tool returns a string starting with one of: OK | TAPPED | VISIBLE | NOT_VISIBLE |
@@ -84,12 +86,17 @@ object MobileTestAgent {
 
                     ANTI-PATTERNS — DO NOT:
                       - Call startTestingScenario more than once — it is the FIRST action only.
+                      - Call launchAppByPackage for the SAME package you passed to startTestingScenario.
+                        launchAppByPackage is ONLY for switching to a different app mid-scenario.
+                      - Emit a tool call with empty/missing arguments. Every `tap` call MUST include `text`.
+                        If you do not know what to tap, call findUiElementsByText or getScreenDump first.
                       - Tap an app icon / launcher / home screen to open the target app. The app is launched
                         programmatically via ADB inside startTestingScenario.
                       - Call closeApp between steps.
                       - Loop the same failing tool call > 2x in a row.
                       - Skip verification.
-                      - Invent selectors not seen on screen — call findUiElementsByText or getScreenDump first.
+                      - Invent selectors not seen on screen — call findUiElementsByText, perceiveScreen,
+                        or getScreenDump first.
 
                     TERMINATION:
                       Stop only after closeApp + the final summary message. Format:

--- a/src/main/kotlin/agent/tool/mobile/test/MobileTestTools.kt
+++ b/src/main/kotlin/agent/tool/mobile/test/MobileTestTools.kt
@@ -1,11 +1,13 @@
 package agent.tool.mobile.test
 
 import agent.tool.mobile.test.utils.AdbUtils
+import agent.tool.mobile.test.utils.PageNode
 import agent.tool.mobile.test.utils.UiAutomatorUtils
 import agent.tool.mobile.test.utils.UiMatchResult
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.core.tools.annotations.Tool
 import ai.koog.agents.core.tools.reflect.ToolSet
+import kotlinx.coroutines.delay
 
 /**
  * All tools return strings prefixed with a STATUS token the agent can pattern-match:
@@ -30,6 +32,11 @@ class MobileTestTools : ToolSet {
         if (connect.contains("No devices") || connect.startsWith("Failed") || connect.startsWith("Error")) {
             return "ERROR: $connect"
         }
+        // Idempotent: if the target app is already foreground, skip relaunch so duplicate
+        // calls from the LLM don't restart the app mid-test.
+        if (AdbUtils.foregroundPackage() == appPackage) {
+            return "OK: $appPackage already foreground (startTestingScenario is a no-op — proceed to next step)"
+        }
         AdbUtils.runAdb("shell", "input", "keyevent", "224") // KEYCODE_WAKEUP
         Thread.sleep(300)
         AdbUtils.runAdb("shell", "wm", "dismiss-keyguard")
@@ -48,11 +55,12 @@ class MobileTestTools : ToolSet {
                 "Returns a list of matches (empty list = not found)."
     )
     fun findUiElementsByText(
-        @LLMDescription("Text fragment to search for (case-insensitive substring match).")
-        text: String,
+        @LLMDescription("Text fragment to search for (case-insensitive substring match). Required — must be non-empty.")
+        text: String = "",
         @LLMDescription("Attribute to filter on: 'text', 'content-desc', 'resource-id', or 'any' (default).")
         selectorType: String = "any"
     ): List<UiMatchResult> {
+        if (text.isBlank()) return emptyList()
         return UiAutomatorUtils.findUiElementsByText(text, selectorType)
     }
 
@@ -64,18 +72,20 @@ class MobileTestTools : ToolSet {
                 "When ambiguous, retry with position=1, 2, ... — do not re-search with different text."
     )
     fun tap(
-        @LLMDescription("Selector value (text, content-desc, or resource-id fragment).")
-        text: String,
+        @LLMDescription("Selector value (text, content-desc, or resource-id fragment). Required — must be non-empty.")
+        text: String = "",
         @LLMDescription("Attribute to match on: 'text', 'content-desc', 'resource-id', or 'any' (default).")
         selectorType: String = "any",
         @LLMDescription("0-based index when multiple elements match. Default 0 = first match.")
         position: Int = 0
     ): String {
+        if (text.isBlank()) return "ERROR: tap requires a non-empty 'text' selector"
         val matches = UiAutomatorUtils.findUiElementsByText(text, selectorType)
         return when {
             matches.isEmpty() -> "NOT_FOUND: no element matches '$text' (selectorType=$selectorType)"
             position !in matches.indices && matches.size > 1 ->
                 "AMBIGUOUS: ${matches.size} matches for '$text' — retry with position in 0..${matches.size - 1}"
+
             else -> UiAutomatorUtils.tapByText(matches, position.coerceIn(0, matches.size - 1))
         }
     }
@@ -86,9 +96,12 @@ class MobileTestTools : ToolSet {
                 "Returns 'TAPPED: (x,y)' or 'ERROR: ...'."
     )
     fun tapByCoordinates(
-        @LLMDescription("X coordinate in pixels.") x: Int,
-        @LLMDescription("Y coordinate in pixels.") y: Int
-    ): String = UiAutomatorUtils.tapByCoordinates(x, y)
+        @LLMDescription("X coordinate in pixels. Required — must be >= 0.") x: Int = -1,
+        @LLMDescription("Y coordinate in pixels. Required — must be >= 0.") y: Int = -1
+    ): String {
+        if (x < 0 || y < 0) return "ERROR: tapByCoordinates requires non-negative x and y (got x=$x, y=$y)"
+        return UiAutomatorUtils.tapByCoordinates(x, y)
+    }
 
     @Tool
     @LLMDescription(
@@ -97,10 +110,11 @@ class MobileTestTools : ToolSet {
                 "If NOT_VISIBLE, consider scrolling or waiting before declaring the step failed."
     )
     fun verifyElementVisible(
-        @LLMDescription("Text fragment expected on screen.") text: String,
+        @LLMDescription("Text fragment expected on screen. Required — must be non-empty.") text: String = "",
         @LLMDescription("Attribute to match on: 'text', 'content-desc', 'resource-id', or 'any' (default).")
         selectorType: String = "any"
     ): String {
+        if (text.isBlank()) return "ERROR: verifyElementVisible requires a non-empty 'text' selector"
         val matches = UiAutomatorUtils.findUiElementsByText(text, selectorType)
         return if (matches.isEmpty()) "NOT_VISIBLE: '$text' not on screen"
         else "VISIBLE: ${matches.size} match(es) for '$text'"
@@ -112,10 +126,11 @@ class MobileTestTools : ToolSet {
                 "Returns 'OK: gone' or 'NOT_VISIBLE: still present'."
     )
     fun verifyElementNotVisible(
-        @LLMDescription("Text fragment that should NOT be on screen.") text: String,
+        @LLMDescription("Text fragment that should NOT be on screen. Required — must be non-empty.") text: String = "",
         @LLMDescription("Attribute to match on: 'text', 'content-desc', 'resource-id', or 'any' (default).")
         selectorType: String = "any"
     ): String {
+        if (text.isBlank()) return "ERROR: verifyElementNotVisible requires a non-empty 'text' selector"
         val matches = UiAutomatorUtils.findUiElementsByText(text, selectorType)
         return if (matches.isEmpty()) "OK: '$text' is not visible (as expected)"
         else "NOT_VISIBLE: '$text' is still visible (${matches.size} match(es))"
@@ -127,10 +142,10 @@ class MobileTestTools : ToolSet {
                 "Bounded 50..10000. Returns 'OK: waited <ms>ms'."
     )
     suspend fun wait(
-        @LLMDescription("Milliseconds to sleep (50..10000).") ms: Int
+        @LLMDescription("Milliseconds to sleep (50..10000). Defaults to 500 if omitted.") ms: Int = 500
     ): String {
         val bounded = ms.coerceIn(50, 10000)
-        kotlinx.coroutines.delay(bounded.toLong())
+        delay(bounded.toLong())
         return "OK: waited ${bounded}ms"
     }
 
@@ -144,6 +159,96 @@ class MobileTestTools : ToolSet {
         if (xml.startsWith("ERROR:")) return xml
         return if (xml.length > 2000) xml.take(2000) + "\n... [truncated, use findUiElementsByText for targeted search]"
         else xml
+    }
+
+    @Tool
+    @LLMDescription(
+        "Return a compact JSON snapshot of every meaningful element on the current screen — " +
+                "interactive (clickable/long-clickable/focusable) AND non-interactive (labels, images). " +
+                "Each item has: i (index), role ('button'|'input'|'text'|'image'|'list'|'listItem'|'tab'|" +
+                "'toggle'|'scroll'|'dialog'|'container'), text, desc (content-desc), id (resource-id suffix), " +
+                "childTexts (descendant labels in visual order — surfaces nested texts under a card), " +
+                "bounds [l,t,r,b], cx, cy (tap center), parent (index of nearest interactive ancestor, " +
+                "or -1), and clickable/long/enabled/selected/checked flags. " +
+                "Sorted top-to-bottom, left-to-right. Capped at ~60 items / ~6KB with a 'truncated' flag. " +
+                "Use this for ANY generic step (positional, semantic, descriptive, icon-only, ambiguous). " +
+                "Pick the right item by reasoning over childTexts/role/parent, then tap via tapByCoordinates(cx,cy). " +
+                "Returns 'OK: <json>' or 'ERROR: ...'."
+    )
+    fun perceiveScreen(): String {
+        return try {
+            val nodes = UiAutomatorUtils.buildPageModel(maxItems = 40)
+            if (nodes.isEmpty()) {
+                val dump = UiAutomatorUtils.dumpUiHierarchyRaw()
+                if (dump.startsWith("ERROR:")) return dump
+                return "OK: ${buildPageJson(nodes, truncated = false)}"
+            }
+            val (w, h) = UiAutomatorUtils.getScreenSize() ?: (0 to 0)
+            var truncated = false
+            var items = nodes
+            var json = buildPageJson(items, truncated = false, screenW = w, screenH = h)
+            while (json.length > 4000 && items.size > 1) {
+                items = items.dropLast(1)
+                truncated = true
+                json = buildPageJson(items, truncated = true, screenW = w, screenH = h)
+            }
+            "OK: $json"
+        } catch (e: Exception) {
+            "ERROR: perceiveScreen failed: ${e.message}"
+        }
+    }
+
+    private fun buildPageJson(items: List<PageNode>, truncated: Boolean, screenW: Int = 0, screenH: Int = 0): String {
+        val sb = StringBuilder()
+        sb.append('{')
+        if (screenW > 0) sb.append("\"w\":").append(screenW).append(',')
+        if (screenH > 0) sb.append("\"h\":").append(screenH).append(',')
+        sb.append("\"count\":").append(items.size)
+        sb.append(",\"truncated\":").append(truncated)
+        sb.append(",\"items\":[")
+        items.forEachIndexed { idx, n ->
+            if (idx > 0) sb.append(',')
+            sb.append('{')
+            sb.append("\"i\":").append(n.i)
+            sb.append(",\"role\":\"").append(escapeJson(n.role)).append('"')
+            if (n.text.isNotEmpty()) sb.append(",\"text\":\"").append(escapeJson(n.text)).append('"')
+            if (n.desc.isNotEmpty()) sb.append(",\"desc\":\"").append(escapeJson(n.desc)).append('"')
+            if (n.id.isNotEmpty()) sb.append(",\"id\":\"").append(escapeJson(n.id)).append('"')
+            if (n.childTexts.isNotEmpty()) {
+                sb.append(",\"childTexts\":[")
+                n.childTexts.forEachIndexed { i, t ->
+                    if (i > 0) sb.append(',')
+                    sb.append('"').append(escapeJson(t)).append('"')
+                }
+                sb.append(']')
+            }
+            sb.append(",\"bounds\":[").append(n.boundsLeft).append(',').append(n.boundsTop).append(',')
+                .append(n.boundsRight).append(',').append(n.boundsBottom).append(']')
+            sb.append(",\"cx\":").append(n.cx).append(",\"cy\":").append(n.cy)
+            if (n.clickable) sb.append(",\"clickable\":true")
+            if (n.long) sb.append(",\"long\":true")
+            if (n.selected) sb.append(",\"selected\":true")
+            if (n.checked) sb.append(",\"checked\":true")
+            if (!n.enabled) sb.append(",\"enabled\":false")
+            sb.append(",\"parent\":").append(n.parent)
+            sb.append('}')
+        }
+        sb.append("]}")
+        return sb.toString()
+    }
+
+    private fun escapeJson(s: String): String {
+        val sb = StringBuilder(s.length + 8)
+        for (c in s) when (c) {
+            '\\' -> sb.append("\\\\")
+            '"' -> sb.append("\\\"")
+            '\n' -> sb.append("\\n")
+            '\r' -> sb.append("\\r")
+            '\t' -> sb.append("\\t")
+            in '\u0000'..'\u001f' -> sb.append("\\u%04x".format(c.code))
+            else -> sb.append(c)
+        }
+        return sb.toString()
     }
 
     @Tool
@@ -203,13 +308,15 @@ class MobileTestTools : ToolSet {
                 "Returns 'OK: typed ...', 'NOT_FOUND: ...', or 'ERROR: ...'."
     )
     fun inputText(
-        @LLMDescription("Selector matching the input field's text, hint (content-desc), or resource-id.")
-        fieldSelector: String,
-        @LLMDescription("Text to type.")
-        text: String,
+        @LLMDescription("Selector matching the input field's text, hint (content-desc), or resource-id. Required.")
+        fieldSelector: String = "",
+        @LLMDescription("Text to type. Required.")
+        text: String = "",
         @LLMDescription("Attribute to match on: 'text', 'content-desc', 'resource-id', or 'any' (default).")
         selectorType: String = "any"
     ): String {
+        if (fieldSelector.isBlank()) return "ERROR: inputText requires a non-empty 'fieldSelector'"
+        if (text.isBlank()) return "ERROR: inputText requires a non-empty 'text' value"
         val result = UiAutomatorUtils.inputTextBySelector(fieldSelector, text, selectorType)
         if (result.startsWith("OK")) hideKeyboard()
         return result
@@ -242,8 +349,9 @@ class MobileTestTools : ToolSet {
                 "Use mid-test when scenario switches apps. Returns 'OK: ...' or 'ERROR: ...'."
     )
     fun launchAppByPackage(
-        @LLMDescription("Android package name, e.g. com.android.settings.") packageName: String
+        @LLMDescription("Android package name, e.g. com.android.settings. Required.") packageName: String = ""
     ): String {
+        if (packageName.isBlank()) return "ERROR: launchAppByPackage requires a non-empty 'packageName'"
         val result = AdbUtils.runAdb(
             "shell", "monkey", "-p", packageName, "-c", "android.intent.category.LAUNCHER", "1"
         )

--- a/src/main/kotlin/agent/tool/mobile/test/utils/PageNode.kt
+++ b/src/main/kotlin/agent/tool/mobile/test/utils/PageNode.kt
@@ -1,0 +1,25 @@
+package agent.tool.mobile.test.utils
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PageNode(
+    val i: Int,
+    val role: String,
+    val text: String,
+    val desc: String,
+    val id: String,
+    val childTexts: List<String>,
+    val clickable: Boolean,
+    val long: Boolean,
+    val enabled: Boolean,
+    val selected: Boolean,
+    val checked: Boolean,
+    val boundsLeft: Int,
+    val boundsTop: Int,
+    val boundsRight: Int,
+    val boundsBottom: Int,
+    val cx: Int,
+    val cy: Int,
+    val parent: Int
+)

--- a/src/main/kotlin/agent/tool/mobile/test/utils/UiAutomatorUtils.kt
+++ b/src/main/kotlin/agent/tool/mobile/test/utils/UiAutomatorUtils.kt
@@ -1,6 +1,13 @@
 package agent.tool.mobile.test.utils
 
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+import java.io.ByteArrayInputStream
+import javax.xml.parsers.DocumentBuilderFactory
+
 object UiAutomatorUtils {
+
+    private val BOUNDS_RE = Regex("\\[(\\d+),(\\d+)\\]\\[(\\d+),(\\d+)\\]")
 
     private val NOISE_ATTRS = Regex(
         " (?:index|package|class|checkable|checked|focusable|focused|scrollable|" +
@@ -8,6 +15,13 @@ object UiAutomatorUtils {
     )
 
     fun dumpUiHierarchy(): String {
+        val raw = dumpUiHierarchyRaw()
+        if (raw.startsWith("ERROR:")) return raw
+        return NOISE_ATTRS.replace(raw, "")
+    }
+
+    /** Raw uiautomator XML — keeps every attribute. Used by the page-model parser. */
+    fun dumpUiHierarchyRaw(): String {
         val dumpResult = AdbUtils.runAdb("shell", "uiautomator", "dump")
         if (dumpResult.contains("Error")) {
             return "ERROR: Failed to dump UI hierarchy: $dumpResult"
@@ -16,7 +30,7 @@ object UiAutomatorUtils {
         val xml = AdbUtils.runAdb("shell", "cat", xmlPath)
         if (xml.isBlank() || xml.contains("Error") || xml.startsWith("Failed"))
             return "ERROR: Failed to read UI hierarchy XML."
-        return NOISE_ATTRS.replace(xml, "")
+        return xml
     }
 
     fun getScreenSize(): Pair<Int, Int>? {
@@ -130,4 +144,181 @@ object UiAutomatorUtils {
         return if (result.contains("Error")) "ERROR: horizontal scroll failed: $result"
         else "OK: scrolled horizontally distance=$distance"
     }
+
+    /**
+     * Build a generic page model from the current uiautomator dump.
+     *
+     * Keeps any node that is interactive (clickable/long-clickable/focusable) OR carries a
+     * non-empty text / content-desc. Each kept node is annotated with a coarse semantic [role]
+     * derived from its Android class, plus a [parent] index pointing to the nearest interactive
+     * ancestor so the LLM can see grouping (list ↔ list items, dialog ↔ buttons, etc.).
+     *
+     * Sorted top-to-bottom, left-to-right. Zero-area nodes are dropped. Returns empty on parse
+     * failure — never throws.
+     */
+    fun buildPageModel(maxItems: Int = 60): List<PageNode> {
+        origCounter = 0
+        val xml = dumpUiHierarchyRaw()
+        if (xml.startsWith("ERROR:")) return emptyList()
+        val doc = try {
+            val factory = DocumentBuilderFactory.newInstance().apply {
+                setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+                isNamespaceAware = false
+            }
+            factory.newDocumentBuilder().parse(ByteArrayInputStream(xml.toByteArray(Charsets.UTF_8)))
+        } catch (_: Exception) {
+            return emptyList()
+        }
+
+        val raw = mutableListOf<RawNode>()
+        walk(doc.documentElement, parentInteractiveIdx = -1, out = raw)
+
+        // Re-index in original-doc order, then resolve parent indices, then sort visually.
+        val byOriginalIdx = raw.withIndex().associate { (idx, r) -> r.origId to idx }
+        val resolved = raw.mapIndexed { idx, r ->
+            val parentResolved = if (r.parentOrigId < 0) -1 else byOriginalIdx[r.parentOrigId] ?: -1
+            r.copy(resolvedIdx = idx, resolvedParent = parentResolved)
+        }
+        val sorted = resolved.sortedWith(compareBy({ it.boundsTop }, { it.boundsLeft }))
+            .take(maxItems)
+
+        // After sorting, rebuild indices and remap parent references.
+        val origToNew = sorted.withIndex().associate { (newIdx, r) -> r.resolvedIdx to newIdx }
+        return sorted.mapIndexed { newIdx, r ->
+            PageNode(
+                i = newIdx,
+                role = r.role,
+                text = r.text,
+                desc = r.desc,
+                id = r.id,
+                childTexts = r.childTexts,
+                clickable = r.clickable,
+                long = r.longClickable,
+                enabled = r.enabled,
+                selected = r.selected,
+                checked = r.checked,
+                boundsLeft = r.boundsLeft,
+                boundsTop = r.boundsTop,
+                boundsRight = r.boundsRight,
+                boundsBottom = r.boundsBottom,
+                cx = (r.boundsLeft + r.boundsRight) / 2,
+                cy = (r.boundsTop + r.boundsBottom) / 2,
+                parent = origToNew[r.resolvedParent] ?: -1
+            )
+        }
+    }
+
+    private data class RawNode(
+        val origId: Int,
+        val parentOrigId: Int,
+        val role: String,
+        val text: String,
+        val desc: String,
+        val id: String,
+        val childTexts: List<String>,
+        val clickable: Boolean,
+        val longClickable: Boolean,
+        val enabled: Boolean,
+        val selected: Boolean,
+        val checked: Boolean,
+        val boundsLeft: Int,
+        val boundsTop: Int,
+        val boundsRight: Int,
+        val boundsBottom: Int,
+        val resolvedIdx: Int = -1,
+        val resolvedParent: Int = -1
+    )
+
+    private var origCounter = 0
+
+    private fun walk(node: Node, parentInteractiveIdx: Int, out: MutableList<RawNode>) {
+        if (node.nodeType != Node.ELEMENT_NODE) return
+        val el = node as Element
+        if (el.tagName != "node") {
+            // Root <hierarchy> wrapper — recurse into children.
+            val kids = el.childNodes
+            for (i in 0 until kids.length) walk(kids.item(i), parentInteractiveIdx, out)
+            return
+        }
+
+        val clickable = el.getAttribute("clickable") == "true"
+        val longClickable = el.getAttribute("long-clickable") == "true"
+        val focusable = el.getAttribute("focusable") == "true"
+        val text = el.getAttribute("text").orEmpty()
+        val desc = el.getAttribute("content-desc").orEmpty()
+        val cls = el.getAttribute("class").orEmpty()
+        val resourceId = el.getAttribute("resource-id").orEmpty()
+        val boundsRaw = el.getAttribute("bounds").orEmpty()
+        val bounds = BOUNDS_RE.matchEntire(boundsRaw)?.groupValues?.drop(1)?.map { it.toInt() }
+
+        val keep = (clickable || longClickable || focusable || text.isNotEmpty() || desc.isNotEmpty()) &&
+                bounds != null && (bounds[2] - bounds[0]) > 0 && (bounds[3] - bounds[1]) > 0
+
+        var thisOrigId = -1
+        if (keep) {
+            thisOrigId = origCounter++
+            val childTexts = collectChildTexts(el, includeSelf = false)
+            out.add(
+                RawNode(
+                    origId = thisOrigId,
+                    parentOrigId = parentInteractiveIdx,
+                    role = classify(cls, clickable, longClickable),
+                    text = text,
+                    desc = desc,
+                    id = resourceId.substringAfterLast('/', missingDelimiterValue = resourceId),
+                    childTexts = childTexts,
+                    clickable = clickable,
+                    longClickable = longClickable,
+                    enabled = el.getAttribute("enabled") == "true",
+                    selected = el.getAttribute("selected") == "true",
+                    checked = el.getAttribute("checked") == "true",
+                    boundsLeft = bounds[0],
+                    boundsTop = bounds[1],
+                    boundsRight = bounds[2],
+                    boundsBottom = bounds[3]
+                )
+            )
+        }
+
+        val nextParent = if (keep && (clickable || longClickable)) thisOrigId else parentInteractiveIdx
+        val kids = el.childNodes
+        for (i in 0 until kids.length) walk(kids.item(i), nextParent, out)
+    }
+
+    private fun collectChildTexts(el: Element, includeSelf: Boolean): List<String> {
+        val acc = mutableListOf<String>()
+        fun visit(n: Node, isRoot: Boolean) {
+            if (n.nodeType != Node.ELEMENT_NODE) return
+            val e = n as Element
+            if (e.tagName == "node" && !(isRoot && !includeSelf)) {
+                e.getAttribute("text").takeIf { it.isNotEmpty() }?.let { acc.add(it) }
+                e.getAttribute("content-desc").takeIf { it.isNotEmpty() }?.let { acc.add(it) }
+            }
+            val kids = e.childNodes
+            for (i in 0 until kids.length) visit(kids.item(i), isRoot = false)
+        }
+        visit(el, isRoot = true)
+        return acc.distinct()
+    }
+
+    private fun classify(cls: String, clickable: Boolean, longClickable: Boolean): String {
+        val c = cls.substringAfterLast('.')
+        return when {
+            c.equals("EditText", ignoreCase = true) || c.contains("AutoComplete", ignoreCase = true) -> "input"
+            c.contains("Switch", ignoreCase = true) || c.contains("CheckBox", ignoreCase = true) ||
+                    c.contains("RadioButton", ignoreCase = true) || c.contains("ToggleButton", ignoreCase = true) -> "toggle"
+            c.contains("Button", ignoreCase = true) -> "button"
+            c.contains("TabItem", ignoreCase = true) || c.contains("Tab", ignoreCase = true) &&
+                    !c.contains("Layout", ignoreCase = true) -> "tab"
+            c.contains("RecyclerView", ignoreCase = true) || c.equals("ListView", ignoreCase = true) ||
+                    c.contains("GridView", ignoreCase = true) -> "list"
+            c.contains("ScrollView", ignoreCase = true) -> "scroll"
+            c.contains("Dialog", ignoreCase = true) || c.contains("AlertDialog", ignoreCase = true) -> "dialog"
+            c.contains("ImageView", ignoreCase = true) -> if (clickable || longClickable) "button" else "image"
+            c.contains("TextView", ignoreCase = true) -> if (clickable || longClickable) "button" else "text"
+            (clickable || longClickable) -> "listItem"
+            else -> "container"
+        }
+    }
+
 }

--- a/web/src/pages/home/Home.module.css
+++ b/web/src/pages/home/Home.module.css
@@ -199,6 +199,15 @@
   color: var(--color-primary-contrast);
   padding: 10px 18px;
   font-size: 0.92rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.runArrow {
+  font-size: 1.4rem;
+  line-height: 1;
+  margin-top: -1px;
 }
 
 .btnPrimary {
@@ -254,6 +263,7 @@
   padding: 5px 9px;
   font-size: 0.78rem;
   min-width: 40px;
+  flex: 0 0 auto;
 }
 
 .buttonGroup {
@@ -509,4 +519,20 @@
   .stepItem {
     padding: 8px 10px;
   }
+}
+
+.spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  margin-right: 8px;
+  vertical-align: -2px;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: spinnerRotate 0.8s linear infinite;
+}
+
+@keyframes spinnerRotate {
+  to { transform: rotate(360deg); }
 }

--- a/web/src/pages/home/Home.tsx
+++ b/web/src/pages/home/Home.tsx
@@ -123,8 +123,6 @@ function Home() {
           setCurrentScenarioId(docRef.id);
         }
         setError(null);
-        setSuccess(t('home.autoSaved'));
-        setTimeout(() => setSuccess(null), 1500);
       } catch (err) {
         setError(t('home.errAutoSave'));
         setSuccess(null);
@@ -323,11 +321,6 @@ function Home() {
 
         {/* Right Panel - Scenario Editor */}
         <div className={styles.rightPanel}>
-          <div className={styles.panelTitle}>
-            <span className="icon">⚙️</span>
-            {currentScenarioId ? t('home.editScenario') : t('home.createNew')}
-          </div>
-
           <div className={styles.formSection}>
             <div className={styles.formSectionTitle}>
               <span className="icon">🎯</span>{t('home.testObjective')}
@@ -430,7 +423,17 @@ function Home() {
                 className={`${styles.button} ${styles.btnRunTest}`}
                 onClick={isLoading ? handleStopTest : handleRunTest}
               >
-                {isLoading ? t('home.stopTest') : t('home.runTest')}
+                {isLoading ? (
+                  <>
+                    <span className={styles.spinner} aria-hidden="true" />
+                    {t('home.stopTest')}
+                  </>
+                ) : (
+                  <>
+                    {t('home.runTest')}
+                    <span aria-hidden="true" className={styles.runArrow}>›</span>
+                  </>
+                )}
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Remove auto-saved toast when updating a goal
- Remove "Edit Scenario / Create New Scenario" panel labels
- Add animated spinner icon to Stop Test button while test is running
- Add `›` arrow icon to Run Test button, aligned via flexbox
- Fix Save/Cancel step edit buttons being oversized (set `flex: 0 0 auto` on `.btnSmall`)

## Test plan
- [ ] Edit a test goal — no "Auto-saved" toast appears
- [ ] Click Run Test — button shows `›` icon aligned with text
- [ ] Start a test — button switches to Stop Test with spinning loader
- [ ] Edit a step — Save/Cancel buttons are compact, not full-width