### PR TITLE
Reliable video recording + drop closeApp step

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ These behaviors are load-bearing — see [docs/ai-agent.md](docs/ai-agent.md) an
 - **Status-prefixed tool returns.** Every `@Tool` returns a `String` starting with one of `OK | TAPPED | VISIBLE | NOT_VISIBLE | NOT_FOUND | AMBIGUOUS | ERROR | TIMEOUT`. The system prompt tells the LLM to pattern-match the prefix. Preserve this when adding tools — return strings, never throw.
 - **Device serial pinning.** `AdbUtils.runAdb()` injects `-s <serial>` after `connectDevice()` picks a target. Don't bypass it with raw `ProcessBuilder("adb", …)` calls.
 - **`MAX_TOKENS_THRESHOLD = 8000`** in `TestingStrategy.kt`. Lower values trigger compression too aggressively and the agent forgets which step it's on.
-- **`startTestingScenario` once, first; `closeApp` once, last.** The system prompt forbids any "tap launcher to open the app" recovery — launch is handled programmatically.
+- **`startTestingScenario` once, first.** The system prompt forbids any "tap launcher to open the app" recovery — launch is handled programmatically. The agent stops immediately after the final-step summary; there is no explicit close step.
 - **`hideKeyboard` uses `KEYCODE_BACK` (4)**, not `KEYCODE_ESCAPE`. Empirically required on the target device; documented inline.
 
 ## Common commands

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,6 @@ flowchart LR
 2. The frontend POSTs the scenario to the Ktor server.
 3. `MobileTestAgent` (a Koog `AIAgent`) interprets each step, calls `@Tool`-annotated functions, and verifies the result before continuing.
 4. The tools layer drives the device on the target platform — **Android, iOS, or React Native** — and reads UI state back.
-5. After `closeApp`, the agent emits a PASS/FAIL summary per step, which is returned to the dashboard.
+5. After the final step verification, the agent emits a PASS/FAIL summary per step, which is returned to the dashboard.
 
 For the deeper "how" — see [architecture.md](architecture.md) and [ai-agent.md](ai-agent.md).

--- a/docs/ai-agent.md
+++ b/docs/ai-agent.md
@@ -80,8 +80,7 @@ The full text lives inline in [MobileTestAgent.kt](../src/main/kotlin/agent/Mobi
 
 1. **First action:** `startTestingScenario(appPackage)` — passing the *exact* `App package` from the user message. Connects ADB, force-stops stale instances, launches the package, verifies foreground. If it returns `OK`, the app is on screen — the model is forbidden from tapping launcher/home icons to "open" it (a common LLM failure mode).
 2. **Execute each step in order**, one at a time, starting from the current screen.
-3. **Final action:** `closeApp` once.
-4. **Emit a single assistant message** listing each step as `PASS`/`FAIL` with a one-line reason.
+3. **After the last step is verified**, emit a single assistant message listing each step as `PASS`/`FAIL` with a one-line reason, and stop. No explicit close step.
 
 ### Per-step loop: act → verify → recover
 
@@ -111,14 +110,13 @@ The model parses this prefix to decide its next action. This is a deliberate cho
 
 * Don't call `startTestingScenario` more than once.
 * Don't tap the launcher/home screen to open the target app.
-* Don't call `closeApp` between steps.
 * Don't loop the same failing call more than twice.
 * Don't skip verification.
 * Don't invent selectors not seen on screen — call `findUiElementsByText` or `getScreenDump` first.
 
 ### Termination
 
-Stop only after `closeApp` + the final summary message. Format:
+Stop immediately after the final summary message. Format:
 
 ```
 Step 1: PASS — <one-line reason>
@@ -214,7 +212,5 @@ Tool called: tool wait, args {ms=500}
 Tool called: tool verifyElementVisible, args {text=Username}
   → VISIBLE: 1 match(es) for 'Username'
 ... (continues for each step) ...
-Tool called: tool closeApp
-  → OK: App 'com.example.myapp' has been force-stopped.
 onAgentFinished: Step 1: PASS — ... Step 2: PASS — ... etc.
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,7 +10,7 @@ Content negotiation uses `kotlinx.serialization` (pretty-printed, lenient, ignor
 
 ## `POST /run-test`
 
-Runs a single test scenario on the connected device. **Synchronous** — the response returns only after the agent's `closeApp` + final summary, so set a generous client timeout (the frontend uses 3 minutes).
+Runs a single test scenario on the connected device. **Synchronous** — the response returns only after the agent's final summary, so set a generous client timeout (the frontend uses 3 minutes).
 
 ### Request body
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,7 +53,7 @@ HOME_PATH=/home/<you>/mobile-tester-artifacts
 
 ## 3. Run the backend
 
-The quickest path is the convenience script — it starts the Ktor backend (`:8080`) and the Vite dashboard (`:5173`) in parallel, installs web deps if missing, and opens the dashboard in your browser:
+The quickest path is the convenience script — it starts the Ktor backend (`:8080`), **waits for it to accept connections** (so the dashboard's first request doesn't race the boot), then starts the Vite dashboard (`:5173`), installs web deps if missing, and opens the dashboard in your browser:
 
 ```bash
 ./start.sh
@@ -148,8 +148,7 @@ The backend will:
 1. Connect to the device (`AdbUtils.connectDevice`).
 2. Wake the screen, dismiss the keyguard, force-stop any stale instance, `monkey`-launch the package, verify foreground.
 3. Run the LLM ↔ tool loop until each step is verified.
-4. `closeApp`.
-5. Return a PASS/FAIL summary as the HTTP response body.
+4. Return a PASS/FAIL summary as the HTTP response body.
 
 ---
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -37,12 +37,11 @@ Defined in [agent/tool/mobile/test/MobileTestTools.kt](../src/main/kotlin/agent/
 ### Lifecycle
 
 #### `startTestingScenario(appPackage: String): String`
-First action in every run. Connects ADB, wakes screen, dismisses keyguard, force-stops any stale instance, launches the package via `monkey`, and **verifies** it reached the foreground (retrying once). On success the target app is already on screen — the model is forbidden from "manually" tapping a launcher icon.
+First action in every run. Connects ADB, wakes screen, dismisses keyguard, force-stops any stale instance, launches the package via `monkey`, and **verifies** it reached the foreground. On success the target app is already on screen — the model is forbidden from "manually" tapping a launcher icon.
 
-> Returns `OK: launched <package> (foreground confirmed)` or `ERROR: ...`.
+Calling it a second time in the same run is a hard no-op: the tool tracks a `scenarioStarted` flag and returns an `ERROR` directing the LLM to proceed with Step 1 instead of restarting the app mid-test.
 
-#### `closeApp(): String`
-Final action. Reads `dumpsys activity top` to find the current foreground package and `am force-stop`s it.
+> Returns `OK: launched <package> (foreground confirmed)`, `OK: launched <package> (process running; foreground check inconclusive)`, or `ERROR: ...`.
 
 #### `launchAppByPackage(packageName: String): String`
 Mid-run app switch (e.g. open Settings to toggle airplane mode, return to the app under test).
@@ -147,9 +146,8 @@ The `@Tool` methods are thin wrappers — the real work lives in three utility o
 * **`runAdb(vararg args)`** — `ProcessBuilder("adb", "-s", serial, …args).redirectErrorStream(true).start()`, returns trimmed stdout. Swallows exceptions into an `Error running adb …` string.
 * **`getDevices()`** — parses `adb devices` output into a list, dropping the header.
 * **`connectDevice()`** — restarts the adb server if any devices are offline, then picks a target: emulator preferred, otherwise the first online device.
-* **`closeCurrentApp()`** — regex-extracts `ACTIVITY <pkg>/...` from `dumpsys activity top` and `am force-stop`s it.
-* **`foregroundPackage()`** — same regex without the stop.
-* **`launchAndVerify(packageName)`** — `monkey -p <pkg> -c android.intent.category.LAUNCHER 1`, sleeps 1.5s, re-reads `foregroundPackage()`, retries once after 2.5s if it doesn't match.
+* **`foregroundPackage()`** — checks `mCurrentFocus` / `mFocusedApp` from `dumpsys window` first, then falls back to the last `ACTIVITY` entry from `dumpsys activity top`. Multiple sources avoid false negatives during launcher transitions.
+* **`launchAndVerify(packageName)`** — `monkey -p <pkg> -c android.intent.category.LAUNCHER 1`, then polls `foregroundPackage()` for up to ~6s. If the process is alive (`pidof`) but foreground detection still races, treats it as success rather than failing the run.
 * **`deviceInformation()`** — multi-prop dump for diagnostics.
 
 ### `UiAutomatorUtils` — hierarchy + interaction

--- a/src/main/kotlin/agent/MobileTestAgent.kt
+++ b/src/main/kotlin/agent/MobileTestAgent.kt
@@ -56,8 +56,9 @@ object MobileTestAgent {
                          home screen entry to open it. If it returns ERROR, stop and FAIL the scenario;
                          do not try to open the app manually.
                       2. Execute every step in order, one step at a time, starting from the app's current screen.
-                      3. Final action: call closeApp once.
-                      4. After closeApp, emit ONE assistant message summarising each step as PASS or FAIL with a one-line reason.
+                      3. After the LAST step is verified, immediately emit ONE assistant message summarising
+                         each step as PASS or FAIL with a one-line reason, and STOP. Do not perform any extra
+                         actions, screenshots, or cleanup after the last step's verification.
 
                     PER-STEP LOOP (act → verify → recover):
                       a) Act: take the smallest tool action that advances the step.
@@ -95,14 +96,13 @@ object MobileTestAgent {
                         If you do not know what to tap, call findUiElementsByText or getScreenDump first.
                       - Tap an app icon / launcher / home screen to open the target app. The app is launched
                         programmatically via ADB inside startTestingScenario.
-                      - Call closeApp between steps.
                       - Loop the same failing tool call > 2x in a row.
                       - Skip verification.
                       - Invent selectors not seen on screen — call findUiElementsByText, perceiveScreen,
                         or getScreenDump first.
 
                     TERMINATION:
-                      Stop only after closeApp + the final summary message. Format:
+                      Stop immediately after emitting the final summary message. Format:
                         Step 1: PASS — <one-line reason>
                         Step 2: FAIL — <one-line reason>
                         ...

--- a/src/main/kotlin/agent/reporting/VideoChunker.kt
+++ b/src/main/kotlin/agent/reporting/VideoChunker.kt
@@ -2,14 +2,22 @@ package agent.reporting
 
 import agent.tool.mobile.test.utils.AdbUtils
 import java.io.File
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.concurrent.thread
 
 /**
- * Records screen video in ~3-minute chunks via `adb shell screenrecord`.
- * Each chunk is pulled to [videoDir] as `chunk-NNN.mp4` and [onChunkPulled] is called.
+ * Records the device screen via `adb shell screenrecord` and pulls a single
+ * playable MP4 to [videoDir] when [stop] is called. [onChunkPulled] is fired
+ * once with the relative path of the produced file.
  *
- * `screenrecord` has a 180s built-in cap; we let it self-terminate then immediately start the next.
+ * Implementation notes:
+ * - screenrecord must receive SIGINT on the *device* side to finalize the MP4
+ *   moov atom. Killing the local `adb shell` process leaves an unplayable file.
+ * - We pass `--time-limit 1800` (max accepted by most Android versions). The
+ *   recording self-terminates after 30 minutes if [stop] is never called.
+ * - After signaling, we wait for the local adb process to exit naturally, then
+ *   poll the remote file size until it stops growing before pulling.
  */
 class VideoChunker(
     private val videoDir: File,
@@ -17,61 +25,70 @@ class VideoChunker(
 ) {
     private val running = AtomicBoolean(false)
     private var workerThread: Thread? = null
-    @Volatile private var currentProcess: Process? = null
-    @Volatile private var currentRemotePath: String? = null
-    @Volatile private var currentChunkIndex: Int = 0
+    @Volatile private var recordProcess: Process? = null
+
+    private val remotePath = "/sdcard/report-video.mp4"
+    private val localName = "recording.mp4"
 
     fun start() {
         if (!running.compareAndSet(false, true)) return
         videoDir.mkdirs()
-        workerThread = thread(name = "video-chunker", isDaemon = true) { loop() }
+        AdbUtils.runAdb("shell", "rm", "-f", remotePath)
+        val cmd = buildList {
+            add("adb")
+            AdbUtils.targetSerial?.let { add("-s"); add(it) }
+            add("shell"); add("screenrecord"); add("--time-limit"); add("1800"); add(remotePath)
+        }
+        recordProcess = try {
+            ProcessBuilder(cmd).redirectErrorStream(true).start()
+        } catch (e: Exception) {
+            running.set(false)
+            null
+        }
+        workerThread = thread(name = "video-recorder", isDaemon = true) {
+            // Drain stdout so the process doesn't block on a full pipe.
+            try { recordProcess?.inputStream?.bufferedReader()?.forEachLine { } } catch (_: Exception) {}
+        }
     }
 
     fun stop() {
         if (!running.compareAndSet(true, false)) return
-        // Kill the active screenrecord on device so the file is finalized.
-        try {
-            AdbUtils.runAdb("shell", "pkill", "-SIGINT", "screenrecord")
-        } catch (_: Exception) { /* best-effort */ }
-        currentProcess?.destroy()
-        workerThread?.join(5_000)
+        val proc = recordProcess ?: return
+
+        // Signal device-side screenrecord so it flushes the moov atom.
+        try { AdbUtils.runAdb("shell", "pkill", "-SIGINT", "screenrecord") } catch (_: Exception) {}
+
+        // Wait for local adb shell to exit cleanly after device-side finishes.
+        if (!proc.waitFor(10, TimeUnit.SECONDS)) {
+            proc.destroy()
+            proc.waitFor(2, TimeUnit.SECONDS)
+        }
+        workerThread?.join(2_000)
         workerThread = null
+        recordProcess = null
+
+        // Wait for the remote file size to stabilize (device flush).
+        waitForRemoteStable()
+
+        val localFile = File(videoDir, localName)
+        val pullResult = AdbUtils.runAdb("pull", remotePath, localFile.absolutePath)
+        AdbUtils.runAdb("shell", "rm", "-f", remotePath)
+
+        if (!pullResult.contains("Error", ignoreCase = true) &&
+            localFile.exists() && localFile.length() > 0
+        ) {
+            onChunkPulled("video/$localName")
+        }
     }
 
-    private fun loop() {
-        while (running.get()) {
-            currentChunkIndex++
-            val padded = currentChunkIndex.toString().padStart(3, '0')
-            val remote = "/sdcard/report-chunk-$padded.mp4"
-            currentRemotePath = remote
-            // screenrecord has its own 180s cap; rely on that.
-            val cmd = buildList {
-                add("adb")
-                AdbUtils.targetSerial?.let { add("-s"); add(it) }
-                add("shell"); add("screenrecord"); add(remote)
-            }
-            val proc = try {
-                ProcessBuilder(cmd).redirectErrorStream(true).start()
-            } catch (e: Exception) {
-                running.set(false)
-                return
-            }
-            currentProcess = proc
-            try {
-                proc.waitFor()
-            } catch (_: InterruptedException) {
-                // External interruption; fall through and try to pull whatever was written.
-            }
-            currentProcess = null
-            // Give the device a moment to finalize the file.
-            try { Thread.sleep(800) } catch (_: InterruptedException) {}
-            val localName = "chunk-$padded.mp4"
-            val localFile = File(videoDir, localName)
-            val pullResult = AdbUtils.runAdb("pull", remote, localFile.absolutePath)
-            AdbUtils.runAdb("shell", "rm", "-f", remote)
-            if (!pullResult.contains("Error", ignoreCase = true) && localFile.exists() && localFile.length() > 0) {
-                onChunkPulled("video/$localName")
-            }
+    private fun waitForRemoteStable() {
+        var lastSize = -1L
+        repeat(10) {
+            val sizeStr = AdbUtils.runAdb("shell", "stat", "-c", "%s", remotePath).trim()
+            val size = sizeStr.toLongOrNull() ?: return@repeat
+            if (size > 0 && size == lastSize) return
+            lastSize = size
+            try { Thread.sleep(300) } catch (_: InterruptedException) { return }
         }
     }
 }

--- a/src/main/kotlin/agent/tool/mobile/test/MobileTestTools.kt
+++ b/src/main/kotlin/agent/tool/mobile/test/MobileTestTools.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.delay
  */
 class MobileTestTools : ToolSet {
 
+    private var scenarioStarted: Boolean = false
+
     @Tool
     @LLMDescription(
         "Connect the device/emulator and launch the target app via ADB. Call ONCE as the first action. " +
@@ -27,24 +29,24 @@ class MobileTestTools : ToolSet {
         @LLMDescription("Android package name to launch, e.g. com.maikogram. Required.")
         appPackage: String
     ): String {
+        if (scenarioStarted) {
+            return "ERROR: startTestingScenario was already called this run — DO NOT call it again. " +
+                    "The app is already launched. Proceed directly to Step 1 of the scenario."
+        }
         if (appPackage.isBlank()) return "ERROR: appPackage is required"
         val connect = AdbUtils.connectDevice()
         if (connect.contains("No devices") || connect.startsWith("Failed") || connect.startsWith("Error")) {
             return "ERROR: $connect"
         }
-        // Idempotent: if the target app is already foreground, skip relaunch so duplicate
-        // calls from the LLM don't restart the app mid-test.
-        if (AdbUtils.foregroundPackage() == appPackage) {
-            return "OK: $appPackage already foreground (startTestingScenario is a no-op — proceed to next step)"
-        }
         AdbUtils.runAdb("shell", "input", "keyevent", "224") // KEYCODE_WAKEUP
         Thread.sleep(300)
         AdbUtils.runAdb("shell", "wm", "dismiss-keyguard")
         Thread.sleep(200)
-        // Force-stop any stale instance so launch starts from a clean state.
         AdbUtils.runAdb("shell", "am", "force-stop", appPackage)
         Thread.sleep(200)
-        return AdbUtils.launchAndVerify(appPackage)
+        val result = AdbUtils.launchAndVerify(appPackage)
+        if (result.startsWith("OK")) scenarioStarted = true
+        return result
     }
 
     @Tool
@@ -359,14 +361,4 @@ class MobileTestTools : ToolSet {
         else "OK: launched $packageName"
     }
 
-    @Tool
-    @LLMDescription(
-        "Force-stop the current foreground app. Call ONCE as the final action of the test scenario. " +
-                "Returns 'OK: ...' or 'ERROR: ...'."
-    )
-    fun closeApp(): String {
-        val result = AdbUtils.closeCurrentApp()
-        return if (result.startsWith("Failed") || result.startsWith("Error")) "ERROR: $result"
-        else "OK: $result"
-    }
 }

--- a/src/main/kotlin/agent/tool/mobile/test/utils/AdbUtils.kt
+++ b/src/main/kotlin/agent/tool/mobile/test/utils/AdbUtils.kt
@@ -82,29 +82,6 @@ object AdbUtils {
     }
 
     /**
-     * Closes the current foreground application on the device.
-     *
-     * @return A message indicating which app was closed, or a failure message.
-     */
-    fun closeCurrentApp(): String {
-        return try {
-            val output = runAdb("shell", "dumpsys", "activity", "top")
-            
-            val regex = Regex("ACTIVITY\\s+([a-zA-Z0-9_.]+)/")
-            val packageName = regex.find(output)?.groups?.get(1)?.value
-
-            if (packageName != null && packageName != "system") {
-                runAdb("shell", "am", "force-stop", packageName)
-                "App '$packageName' has been force-stopped."
-            } else {
-                "Failed to identify the current foreground app."
-            }
-        } catch (e: Exception) {
-            "Error closing app: ${e.message}"
-        }
-    }
-
-    /**
      * Gathers and returns detailed information about the connected device.
      *
      * @return A formatted string with device information, or an error message.
@@ -113,26 +90,42 @@ object AdbUtils {
      * Returns the package name of the current foreground activity, or null if it can't be read.
      */
     fun foregroundPackage(): String? {
-        val output = runAdb("shell", "dumpsys", "activity", "top")
-        return Regex("ACTIVITY\\s+([a-zA-Z0-9_.]+)/").find(output)?.groups?.get(1)?.value
+        // Try several sources — Android exposes the focused app in different places
+        // and `dumpsys activity top` can briefly still show the launcher mid-transition.
+        val focus = runAdb("shell", "dumpsys", "window")
+        Regex("mCurrentFocus=.*?\\s+([a-zA-Z0-9_.]+)/").find(focus)?.groups?.get(1)?.value?.let { return it }
+        Regex("mFocusedApp=.*?\\s+([a-zA-Z0-9_.]+)/").find(focus)?.groups?.get(1)?.value?.let { return it }
+        val top = runAdb("shell", "dumpsys", "activity", "top")
+        return Regex("ACTIVITY\\s+([a-zA-Z0-9_.]+)/").findAll(top).lastOrNull()?.groups?.get(1)?.value
+    }
+
+    /** True if at least one process for [packageName] is alive on the device. */
+    private fun isProcessRunning(packageName: String): Boolean {
+        val out = runAdb("shell", "pidof", packageName)
+        return out.isNotBlank() && !out.contains("Error") && out.trim().all { it.isDigit() || it == ' ' }
     }
 
     /**
      * Launches an app by package via monkey, then verifies it reached the foreground.
-     * Retries once if the verification fails.
+     * Polls for up to ~6s; if the process is alive but foreground detection still races
+     * (common on the Pixel launcher transition), treat it as success rather than a false alarm.
      */
     fun launchAndVerify(packageName: String): String {
-        repeat(2) { attempt ->
-            val launch = runAdb(
-                "shell", "monkey", "-p", packageName,
-                "-c", "android.intent.category.LAUNCHER", "1"
-            )
-            if (launch.contains("Error") || launch.contains("No activities")) {
-                return "ERROR: failed to launch '$packageName': $launch"
+        val launch = runAdb(
+            "shell", "monkey", "-p", packageName,
+            "-c", "android.intent.category.LAUNCHER", "1"
+        )
+        if (launch.contains("Error") || launch.contains("No activities")) {
+            return "ERROR: failed to launch '$packageName': $launch"
+        }
+        repeat(6) {
+            Thread.sleep(1000)
+            if (foregroundPackage() == packageName) {
+                return "OK: launched $packageName (foreground confirmed)"
             }
-            Thread.sleep(if (attempt == 0) 1500 else 2500)
-            val fg = foregroundPackage()
-            if (fg == packageName) return "OK: launched $packageName (foreground confirmed)"
+        }
+        if (isProcessRunning(packageName)) {
+            return "OK: launched $packageName (process running; foreground check inconclusive)"
         }
         val fg = foregroundPackage() ?: "unknown"
         return "ERROR: launched '$packageName' but foreground is '$fg' after retry"

--- a/start.sh
+++ b/start.sh
@@ -21,6 +21,9 @@ echo "Starting Ktor backend on http://localhost:8080 ..."
 ./gradlew run --console=plain &
 BACKEND_PID=$!
 
+echo "Waiting for backend to accept connections on :8080 ..."
+until curl -sf http://localhost:8080/report >/dev/null 2>&1; do sleep 1; done
+
 echo "Starting web dashboard on http://localhost:5173 ..."
 (cd web && npm run dev) &
 WEB_PID=$!


### PR DESCRIPTION
## Summary
- **Video fix:** rewrite `VideoChunker` to a single `screenrecord` call. Stop now sends SIGINT to the device-side process, waits for the local `adb shell` to exit, and polls the remote file size until stable before pulling — the moov atom is always written, so the resulting `video/recording.mp4` plays in the Reports page and standalone.
- **Drop `closeApp`:** the agent stops immediately after the final PASS/FAIL summary. `startTestingScenario` now tracks an in-class `scenarioStarted` flag so a second call returns `ERROR` instead of restarting the app mid-run.
- **Foreground detection:** `AdbUtils.foregroundPackage()` checks `mCurrentFocus`/`mFocusedApp` first and falls back to `dumpsys activity top`; `launchAndVerify` polls ~6s and treats process-alive as success to survive Pixel launcher transitions.
- **start.sh:** wait for the backend on `:8080` before booting the Vite dashboard so the first dashboard request doesn't race the boot.
- **Docs:** updated `CLAUDE.md`, `docs/README.md`, `docs/ai-agent.md`, `docs/api.md`, `docs/tools.md`, `docs/getting-started.md` to match.

## Test plan
- [ ] Run a multi-step scenario with recording enabled; confirm `reports/latest/video/recording.mp4` plays in the Reports page and in a local player.
- [ ] Re-run with a scenario that intentionally has the agent attempt a second `startTestingScenario` — verify it returns `ERROR` and the run continues.
- [ ] Confirm `./start.sh` no longer fires the dashboard before the backend accepts connections.